### PR TITLE
fix(config): add missing `info_iter_num` parameter to placer configuration

### DIFF
--- a/tools/iEDA/iEDA_config/pl_default_config.json
+++ b/tools/iEDA/iEDA_config/pl_default_config.json
@@ -6,6 +6,7 @@
         "is_congestion_effort": 0,
         "ignore_net_degree": 100,
         "num_threads": 16,
+        "info_iter_num": 10,
         "GP": {
             "Wirelength": {
                 "init_wirelength_coef": 0.25,


### PR DESCRIPTION
This PR aims to add missing `info_iter_num` parameter to placer configuration.