### PR TITLE
fix(step): rename congestion map path in placement step

### DIFF
--- a/src/rtl2gds/step/step.yaml
+++ b/src/rtl2gds/step/step.yaml
@@ -225,7 +225,7 @@ placement:
       TOOL_METRICS_JSON: ${OUTPUT_TOP_NAME}_placement_metrics.json
       TOOL_REPORT_DIR: ./
       DESIGN_EVAL_REPORT: ${OUTPUT_TOP_NAME}_eval
-      CONGESTION_MAP: rt/place_egr_union_overflow.csv
+      CONGESTION_MAP: egr_congestion_map/place_egr_union_overflow.csv
       DENSITY_MAP_CELL: density_map/legalization_allcell_density.csv
       DENSITY_MAP_PIN: density_map/legalization_allcell_pin_density.csv
       DENSITY_MAP_NET: density_map/legalization_allnet_density.csv


### PR DESCRIPTION
Congestion map path has been changed in the new version of iEDA: https://gitee.com/oscc-project/iEDA/commit/015dc847b7f502396d2ea134444c2a236eba9ec0